### PR TITLE
feat: Add open directory functionality

### DIFF
--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -13,6 +13,7 @@ export const EDIT_TAG = 'edit-tag';
 
 // file system operations
 export const OPEN_FILE = 'open-file';
+export const OPEN_DIR = 'open-directory';
 
 export const FILE_DROPPED = 'file-dropped';
 export type FILE_DROPPED_PARAMS = {

--- a/src/main/API/fileOperations.ts
+++ b/src/main/API/fileOperations.ts
@@ -1,12 +1,16 @@
 /* eslint-disable camelcase */
 import { ipcMain, shell } from 'electron';
 import { deleteFile } from '../Database/Models/files';
-import { OPEN_FILE, REMOVE_FILE } from '../../constants/index';
+import { OPEN_DIR, OPEN_FILE, REMOVE_FILE } from '../../constants/index';
 import { IFile } from '../../schema';
 
 export default function initFileOperations() {
-  ipcMain.handle(OPEN_FILE, async (event, file: IFile) => {
+  ipcMain.handle(OPEN_FILE, async (_, file: IFile) => {
     shell.openPath(file.file_path);
+  });
+
+  ipcMain.handle(OPEN_DIR, async (_, file: IFile) => {
+    shell.showItemInFolder(file.file_path);
   });
 
   ipcMain.handle(REMOVE_FILE, async (_, file_id) => {

--- a/src/renderer/API/helper.ts
+++ b/src/renderer/API/helper.ts
@@ -6,6 +6,7 @@ import {
   EDIT_TAG,
   GET_FILES,
   GET_TAGS,
+  OPEN_DIR,
   OPEN_FILE,
   REMOVE_FILE,
   REMOVE_TAG,
@@ -33,6 +34,10 @@ export async function removeFiles(file_id: number) {
 
 export async function openFile(file: IFile) {
   window.electron.ipcRenderer.invoke(OPEN_FILE, file);
+}
+
+export async function openDir(file: IFile) {
+  window.electron.ipcRenderer.invoke(OPEN_DIR, file);
 }
 
 export async function getTags() {

--- a/src/renderer/Components/composite/fileCard.tsx
+++ b/src/renderer/Components/composite/fileCard.tsx
@@ -15,7 +15,7 @@ import {
 } from '../ui/context-menu';
 import { IFile } from '../../../schema';
 import { getFriendlyFileSize } from '../../util';
-import { openFile, removeFiles } from '../../API/helper';
+import { openDir, openFile, removeFiles } from '../../API/helper';
 import { removeFileRedux } from '../../redux/filesSlice';
 
 interface IFileViewTile extends React.HTMLAttributes<HTMLDivElement> {
@@ -57,6 +57,7 @@ export function FileViewTile({
     dispatch(dispatch(removeFileRedux(meta)));
     toast.success('File removed');
   };
+
   useEffect(() => {
     setIsImage(isImagePath(path));
   }, [path]);
@@ -64,6 +65,11 @@ export function FileViewTile({
   const openFileHandler = () => {
     openFile(meta);
     toast.success('File opened');
+  };
+
+  const openDirHandler = () => {
+    openDir(meta);
+    toast.success('Opening Folder');
   };
 
   return (
@@ -95,7 +101,9 @@ export function FileViewTile({
         <ContextMenuContent className="w-40">
           <ContextMenuItem onClick={openFileHandler}>Open</ContextMenuItem>
           <ContextMenuSeparator />
-          <ContextMenuItem>Open Folder</ContextMenuItem>
+          <ContextMenuItem onClick={openDirHandler}>
+            Open Folder
+          </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem>Details</ContextMenuItem>
           <ContextMenuSeparator />


### PR DESCRIPTION
- Added the OPEN_DIR constant to the events.ts file.
- Implemented the openDir function in fileOperations.ts to open the directory of a file.
- Updated helper.ts and fileCard.tsx to include the openDirHandler function for opening the folder associated with a file.