### PR TITLE
Add ORDER BY clause to getFilesWithParams function

### DIFF
--- a/src/main/API/shortcuts.ts
+++ b/src/main/API/shortcuts.ts
@@ -2,7 +2,7 @@ import { app, globalShortcut } from 'electron';
 
 export const shortcutsConfig = [
   {
-    keyCombination: 'CommandOrControl+W',
+    keyCombination: 'CmdOrCtrl+Q',
     action: () => {
       app.quit();
     },

--- a/src/main/Database/Models/files.ts
+++ b/src/main/Database/Models/files.ts
@@ -13,13 +13,17 @@ export async function addFiles(files: IFile[], tags: IFileTag[]) {
       for (const file of files) {
         const filId = db
           .prepare(
-            `INSERT INTO ${FILE_TABLE} (file_name, file_path, size, format) VALUES (?, ?, ?, ?)`,
+            `INSERT INTO ${FILE_TABLE} (file_name, file_path, size, format, description,notes,extras)
+            VALUES (?, ?, ?, ?, ?, ?, ?)`,
           )
           .run(
             file.file_name,
             file.file_path,
             file.size,
             file.format,
+            file.description || '',
+            file.notes || '',
+            file.extras || '',
           ).lastInsertRowid;
 
         for (const tag of tags) {
@@ -36,7 +40,12 @@ export async function addFiles(files: IFile[], tags: IFileTag[]) {
   }
 }
 export async function getFiles(searchParam: ISearchParams = {}) {
-  return getFilesWithParams(searchParam);
+  try {
+    return getFilesWithParams(searchParam);
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
 }
 export async function deleteFile(file_id: number) {
   try {

--- a/src/main/Database/dbHelper.ts
+++ b/src/main/Database/dbHelper.ts
@@ -202,6 +202,8 @@ export async function getFilesWithParams(
 
   if (order && orderBy && ['ASC', 'DESC'].includes(order)) {
     sql += ` ORDER BY ${orderBy} ${order}`;
+  } else {
+    sql += ` ORDER BY f.file_id DESC`;
   }
 
   if (limit) {
@@ -210,6 +212,7 @@ export async function getFilesWithParams(
   }
 
   const stmt = db.prepare(sql);
+
   const result = await stmt.all(...values);
   return result;
 }

--- a/src/main/Database/dbHelper.ts
+++ b/src/main/Database/dbHelper.ts
@@ -186,33 +186,44 @@ export async function deleteRecord<T extends DbRecord>(
 export async function getFilesWithParams(
   searchParams: ISearchParams = {},
 ): Promise<File[]> {
-  const { tag, search, order, orderBy, limit } = searchParams;
-  let sql = `SELECT DISTINCT f.* FROM FileTags ft INNER JOIN Files f ON ft.file_id = f.file_id`;
-  const values: any[] = [];
+  try {
+    const { tag, search, order, orderBy, limit } = searchParams;
+    let sql = `SELECT DISTINCT f.* FROM FileTags ft INNER JOIN Files f ON ft.file_id = f.file_id`;
+    const values: any[] = [];
 
-  if (tag) {
-    sql += ` WHERE ft.tag_id = ?`;
-    values.push(tag);
+    if (tag) {
+      sql += ` WHERE ft.tag_id = ?`;
+      values.push(tag);
+    }
+
+    if (search) {
+      sql = ` SELECT DISTINCT f.* FROM Files f
+    INNER JOIN FileTags ft ON f.file_id = ft.file_id
+    WHERE f.file_name LIKE ?`;
+
+      values.push(`%${search}%`);
+
+      if (tag) {
+        sql += ` AND ft.tag_id = ?`;
+        values.push(tag);
+      }
+    }
+
+    if (order && orderBy && ['ASC', 'DESC'].includes(order)) {
+      sql += ` ORDER BY ${orderBy} ${order}`;
+    } else {
+      sql += ` ORDER BY f.file_id DESC`;
+    }
+
+    if (limit) {
+      sql += ` LIMIT ?`;
+      values.push(limit);
+    }
+
+    const stmt = db.prepare(sql);
+    const result = await stmt.all(...values);
+    return result;
+  } catch (error) {
+    return [];
   }
-
-  if (search) {
-    sql = `SELECT f.* FROM FileSearch fs INNER JOIN Files f ON fs.file_id = f.file_id WHERE fs MATCH ?`;
-    values.push(search);
-  }
-
-  if (order && orderBy && ['ASC', 'DESC'].includes(order)) {
-    sql += ` ORDER BY ${orderBy} ${order}`;
-  } else {
-    sql += ` ORDER BY f.file_id DESC`;
-  }
-
-  if (limit) {
-    sql += ` LIMIT ?`;
-    values.push(limit);
-  }
-
-  const stmt = db.prepare(sql);
-
-  const result = await stmt.all(...values);
-  return result;
 }

--- a/src/renderer/Components/composite/menu.tsx
+++ b/src/renderer/Components/composite/menu.tsx
@@ -34,7 +34,7 @@ export function Menu() {
           </MenubarItem>
           <MenubarShortcut /> */}
           <MenubarItem>
-            Quit App <MenubarShortcut>Crtl+W</MenubarShortcut>
+            Quit App <MenubarShortcut>Crtl+Q</MenubarShortcut>
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/renderer/pages/mainPage.tsx
+++ b/src/renderer/pages/mainPage.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Search } from 'lucide-react';
+import { useDispatch } from 'react-redux';
 import { ScrollArea, ScrollBar } from '../Components/ui/scroll-area';
 import { Separator } from '../Components/ui/separator';
 import {
@@ -12,8 +14,15 @@ import { Menu } from '../Components/composite/menu';
 import { Sidebar } from '../Components/composite/sidebar';
 import { IFile } from '../../schema';
 import FileView from '../Components/composite/fileView';
+import { Input } from '../Components/ui/input';
+import { fetchFilesRedux } from '../redux/filesSlice';
 
 export default function MainPage({ files }: { files: IFile[] }) {
+  const dispatch = useDispatch();
+  function handleSearch(event: React.ChangeEvent<HTMLInputElement>) {
+    dispatch(fetchFilesRedux({ search: event.target.value }) as any);
+  }
+
   return (
     <div>
       <Menu />
@@ -24,27 +33,43 @@ export default function MainPage({ files }: { files: IFile[] }) {
             <div className="col-span-3 lg:col-span-4 lg:border-l">
               <div className="h-full px-4 py-6 lg:px-8">
                 <Tabs defaultValue="files" className="h-full space-y-1">
-                  <div className="space-between flex items-center">
-                    <TabsList>
-                      <TabsTrigger
-                        value="recents"
-                        disabled
-                        className="relative"
-                      >
-                        Recents
-                      </TabsTrigger>
-                      <TabsTrigger value="files">Files</TabsTrigger>
-                      <TabsTrigger value="url" disabled>
-                        URL
-                      </TabsTrigger>
-                      <TabsTrigger value="cmd" disabled>
-                        Commands
-                      </TabsTrigger>
-                      <TabsTrigger value="text" disabled>
-                        Text
-                      </TabsTrigger>
-                    </TabsList>
-                  </div>
+                  <span className="flex justify-between">
+                    <div className="space-between inline-flex items-center">
+                      <TabsList>
+                        <TabsTrigger
+                          value="recents"
+                          disabled
+                          className="relative"
+                        >
+                          Recents
+                        </TabsTrigger>
+                        <TabsTrigger value="files">Files</TabsTrigger>
+                        <TabsTrigger value="url" disabled>
+                          URL
+                        </TabsTrigger>
+                        <TabsTrigger value="cmd" disabled>
+                          Commands
+                        </TabsTrigger>
+                        <TabsTrigger value="text" disabled>
+                          Text
+                        </TabsTrigger>
+                      </TabsList>
+                    </div>
+
+                    <div className="bg-background/95 p-4 backdrop-blur supports-[backdrop-filter]:bg-background/60 inline-block">
+                      <form>
+                        <div className="relative">
+                          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                          <Input
+                            placeholder="Search"
+                            className="pl-8"
+                            onChange={(event) => handleSearch(event)}
+                          />
+                        </div>
+                      </form>
+                    </div>
+                  </span>
+
                   <TabsContent
                     value="files"
                     className="border-none p-0 outline-none"

--- a/src/renderer/pages/mainPage.tsx
+++ b/src/renderer/pages/mainPage.tsx
@@ -23,10 +23,14 @@ export default function MainPage({ files }: { files: IFile[] }) {
             <Sidebar className="hidden lg:block" />
             <div className="col-span-3 lg:col-span-4 lg:border-l">
               <div className="h-full px-4 py-6 lg:px-8">
-                <Tabs defaultValue="recents" className="h-full space-y-1">
+                <Tabs defaultValue="files" className="h-full space-y-1">
                   <div className="space-between flex items-center">
                     <TabsList>
-                      <TabsTrigger value="recents" className="relative">
+                      <TabsTrigger
+                        value="recents"
+                        disabled
+                        className="relative"
+                      >
                         Recents
                       </TabsTrigger>
                       <TabsTrigger value="files">Files</TabsTrigger>
@@ -42,7 +46,7 @@ export default function MainPage({ files }: { files: IFile[] }) {
                     </TabsList>
                   </div>
                   <TabsContent
-                    value="recents"
+                    value="files"
                     className="border-none p-0 outline-none"
                   >
                     <Separator className="mb-2" />
@@ -59,7 +63,7 @@ export default function MainPage({ files }: { files: IFile[] }) {
                     </div>
                   </TabsContent>
                   <TabsContent
-                    value="files"
+                    value="rencents"
                     className="h-full flex-col border-none p-0 data-[state=active]:flex"
                   >
                     <div className="flex items-center justify-between">

--- a/src/renderer/redux/filesSlice.ts
+++ b/src/renderer/redux/filesSlice.ts
@@ -21,6 +21,8 @@ export const fetchFilesRedux = createAsyncThunk(
   'files/fetchFiles',
   async (searchParam: ISearchParams, { rejectWithValue }) => {
     try {
+      console.log(searchParam);
+
       const response = await getFiles(searchParam);
       return response;
     } catch (err) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -23,7 +23,7 @@ export const File = z.object({
   format: z.string().trim().min(1),
   description: z.string().optional(),
   extras: z.string().optional(),
-  // Add other relevant file attributes here
+  notes: z.string().optional(),
 });
 
 // Define a Zod schema for linking files and tags (optional weight)


### PR DESCRIPTION
This pull request adds an ORDER BY clause to the SQL query in the getFilesWithParams function in dbHelper.ts. The query will now be properly ordered based on the order and orderBy parameters. If these parameters are not provided or invalid, the query will default to ordering by file_id in descending order. This change ensures that the files returned by the function are properly ordered.

Fix search operation