### PR TITLE
Refactor electron-builder command in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,4 @@ jobs:
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm exec electron-builder -- --publish always --win --mac --linux
+          npm exec electron-builder -- --publish always --win --linux


### PR DESCRIPTION
This pull request updates the electron-builder command in the publish.yml file. The command has been modified to exclude the macOS platform, resulting in a more streamlined build process.